### PR TITLE
Refactor diagram rendering workflow and update build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - main
     paths-ignore:
-      - "**.{plantuml,puml}"
-      - "**.md"
+      - "**/*.plantuml"
+      - "**/*.md"
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/render-diagrams.yml
+++ b/.github/workflows/render-diagrams.yml
@@ -7,12 +7,12 @@ on:
     branches:
       - main
     paths:
-      - design/**/*.{plantuml,puml}
+      - design/**/*.plantuml
   pull_request:
     branches:
       - main
     paths:
-      - design/**/*.{plantuml,puml}
+      - design/**/*.plantuml
   workflow_dispatch:
 jobs:
   diagrams:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/plantuml
         with:
-          infiles: design/**/*.{plantuml,puml}
+          infiles: design/**/*.plantuml
           outdir: png
       - name: "Upload Diagrams"
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Extract the diagram rendering workflow into a dedicated file and update the build configuration to ignore certain paths during pull requests. Clarify the reason for ignoring the chromatic job in the build file.